### PR TITLE
fix: support custom github pages domains

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Build static site
         run: npm run build
+        env:
+          GITHUB_PAGES_CUSTOM_DOMAIN: ${{ vars.GH_PAGES_CUSTOM_DOMAIN }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/README.md
+++ b/README.md
@@ -28,3 +28,15 @@ To enable it, configure the repository in GitHub:
 1. Open `Settings` -> `Pages`.
 2. Set `Build and deployment` -> `Source` to `GitHub Actions`.
 3. Push to `main` or run `Deploy GitHub Pages` manually from the Actions tab.
+
+### Custom domain
+
+For the default GitHub Pages project URL, such as `https://techrockers.github.io/techrock-website/`, the build uses the repository name as the base path.
+
+For a custom domain, such as `https://techrock.de/`, the site must be built from the web root instead. Add a repository variable in GitHub:
+
+```text
+GH_PAGES_CUSTOM_DOMAIN=techrock.de
+```
+
+Repository variables are not secrets, so this is safe for an open source repository. When this variable is set, the workflow builds root-relative paths for the custom domain.

--- a/src/github-pages.ts
+++ b/src/github-pages.ts
@@ -3,6 +3,9 @@ export function getGitHubPagesBasePath() {
     process.env.GITHUB_REPOSITORY?.split("/") ?? [];
   const repositoryOwner =
     process.env.GITHUB_REPOSITORY_OWNER ?? repositoryOwnerFromSlug;
+  const hasCustomDomain =
+    Boolean(process.env.GITHUB_PAGES_CUSTOM_DOMAIN) ||
+    Boolean(process.env.NEXT_PUBLIC_SITE_DOMAIN);
   const isUserOrOrganizationPage =
     repositoryName.toLowerCase() ===
     `${repositoryOwner.toLowerCase()}.github.io`;
@@ -11,7 +14,7 @@ export function getGitHubPagesBasePath() {
     return "";
   }
 
-  if (!repositoryName || isUserOrOrganizationPage) {
+  if (!repositoryName || isUserOrOrganizationPage || hasCustomDomain) {
     return "";
   }
 


### PR DESCRIPTION
This pull request adds support for deploying the site to a custom domain using GitHub Pages. The main changes ensure that when a custom domain is configured, the build and deployment processes use root-relative paths instead of repository-relative paths. Documentation has also been updated to explain how to set up a custom domain.

**Custom domain support:**

* Updated the `getGitHubPagesBasePath` function in `src/github-pages.ts` to detect when a custom domain is set (via `GITHUB_PAGES_CUSTOM_DOMAIN` or `NEXT_PUBLIC_SITE_DOMAIN`), and to use root-relative paths in that case. [[1]](diffhunk://#diff-951473e11f28b2b60ead901c99128cd24e424eb28282d672532fde3fad332d07R6-R8) [[2]](diffhunk://#diff-951473e11f28b2b60ead901c99128cd24e424eb28282d672532fde3fad332d07L14-R17)
* Modified the GitHub Actions workflow in `.github/workflows/pages.yml` to pass the `GH_PAGES_CUSTOM_DOMAIN` repository variable as an environment variable during the build step.

**Documentation:**

* Added a section to `README.md` explaining how to configure a custom domain for GitHub Pages using the `GH_PAGES_CUSTOM_DOMAIN` repository variable, and clarifying the difference in base path handling between default and custom domains.