### PR TITLE
fix: honor custom domain build variable

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build static site
         run: npm run build
         env:
-          GITHUB_PAGES_CUSTOM_DOMAIN: ${{ vars.GH_PAGES_CUSTOM_DOMAIN }}
+          GH_PAGES_CUSTOM_DOMAIN: ${{ vars.GH_PAGES_CUSTOM_DOMAIN }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/src/github-pages.ts
+++ b/src/github-pages.ts
@@ -4,6 +4,7 @@ export function getGitHubPagesBasePath() {
   const repositoryOwner =
     process.env.GITHUB_REPOSITORY_OWNER ?? repositoryOwnerFromSlug;
   const hasCustomDomain =
+    Boolean(process.env.GH_PAGES_CUSTOM_DOMAIN) ||
     Boolean(process.env.GITHUB_PAGES_CUSTOM_DOMAIN) ||
     Boolean(process.env.NEXT_PUBLIC_SITE_DOMAIN);
   const isUserOrOrganizationPage =


### PR DESCRIPTION
This pull request makes a minor fix to environment variable usage for GitHub Pages custom domains, ensuring consistency between the build process and runtime checks.

- **Build process environment variable fix:**
  * In `.github/workflows/pages.yml`, the environment variable passed to the build step is changed from `GITHUB_PAGES_CUSTOM_DOMAIN` to `GH_PAGES_CUSTOM_DOMAIN` to match expected usage.

- **Runtime environment variable check:**
  * In `src/github-pages.ts`, the logic for determining if a custom domain is set now also checks for `GH_PAGES_CUSTOM_DOMAIN`, in addition to the previous variables.