### PR TITLE
feat: add product URL and update links for 'Sag Mal Ehrlich' product

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -455,6 +455,33 @@ p {
   text-transform: uppercase;
 }
 
+.product-title-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.product-title-link:hover,
+.product-title-link:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.14rem;
+}
+
+.product-cta-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 0.65rem;
+  color: var(--ridge);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.product-cta-link:hover,
+.product-cta-link:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.16rem;
+}
+
 .product-tags {
   display: flex;
   flex-wrap: wrap;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ type Product = {
   imageAlt?: string;
   imageWidth?: number;
   imageHeight?: number;
+  url?: string;
 };
 
 const products: Product[] = [
@@ -31,6 +32,7 @@ const products: Product[] = [
     imageWidth: 167,
     imageHeight: 90,
     shotClass: "mal-ehrlich-shot",
+    url: "https://sag-mal-ehrlich.de",
     badge: "Online",
     badgeTone: "online",
     detailsLabel: "Details",
@@ -240,8 +242,31 @@ export default function Home() {
               </div>
               <div className="product-content">
                 <p className="product-kind">{product.kind}</p>
-                <h3>{product.name}</h3>
+                <h3>
+                  {product.url ? (
+                    <a
+                      href={product.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="product-title-link"
+                    >
+                      {product.name}
+                    </a>
+                  ) : (
+                    product.name
+                  )}
+                </h3>
                 <p>{product.teaser}</p>
+                {product.url ? (
+                  <a
+                    href={product.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="product-cta-link"
+                  >
+                    App aufrufen <span aria-hidden="true">↗</span>
+                  </a>
+                ) : null}
                 <div className="product-tags">
                   {product.stats.map((stat) => (
                     <span key={stat}>{stat}</span>
@@ -252,6 +277,16 @@ export default function Home() {
                   {product.description.split("\n\n").map((paragraph) => (
                     <p key={paragraph}>{paragraph}</p>
                   ))}
+                  {product.url ? (
+                    <a
+                      href={product.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="product-cta-link"
+                    >
+                      App aufrufen <span aria-hidden="true">↗</span>
+                    </a>
+                  ) : null}
                 </details>
               </div>
             </article>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -248,6 +248,7 @@ export default function Home() {
                       href={product.url}
                       target="_blank"
                       rel="noopener noreferrer"
+                      aria-label={`${product.name} (oeffnet in neuem Tab)`}
                       className="product-title-link"
                     >
                       {product.name}
@@ -262,6 +263,7 @@ export default function Home() {
                     href={product.url}
                     target="_blank"
                     rel="noopener noreferrer"
+                    aria-label="App aufrufen (oeffnet in neuem Tab)"
                     className="product-cta-link"
                   >
                     App aufrufen <span aria-hidden="true">↗</span>
@@ -282,6 +284,7 @@ export default function Home() {
                       href={product.url}
                       target="_blank"
                       rel="noopener noreferrer"
+                      aria-label="App aufrufen (oeffnet in neuem Tab)"
                       className="product-cta-link"
                     >
                       App aufrufen <span aria-hidden="true">↗</span>


### PR DESCRIPTION
This pull request enhances the display and interactivity of product links on the homepage by introducing dedicated styles and UI elements for products with associated URLs. The changes improve user experience by making product names clickable (when a URL is present) and adding clear call-to-action (CTA) links to access the product.

**UI and Styling Improvements:**

* Added `.product-title-link` and `.product-cta-link` CSS classes in `app/globals.css` to style product titles as links and provide visually distinct CTA links, including hover and focus-visible states.

**Homepage Product Listing Enhancements:**

* Updated the `Product` type in `app/page.tsx` to optionally include a `url` property, enabling products to specify a link.
* Modified the product data to include a `url` for relevant products (e.g., "https://sag-mal-ehrlich.de").
* Updated the homepage rendering logic to:
  - Display the product name as a clickable link when a `url` is present, using the new `.product-title-link` class.
  - Add a prominent "App aufrufen" CTA link (with an arrow icon) below the teaser and inside the product details section for products with a `url`, using the `.product-cta-link` class. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L243-R269) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R280-R289)